### PR TITLE
Sync .gitmodules with jcsda/jcsda_emc_spack_stack hash commit.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,11 +1,9 @@
 [submodule "spack"]
   path = spack
-  ##url = https://github.com/spack/spack
-  ##branch = develop
-  #url = https://github.com/jcsda/spack
-  #branch = spack-stack-1.4.0
-  url = https://github.com/climbfuji/spack
-  branch = feature/merge_rel140_to_jcsda_emc_spack_stack
+  #url = https://github.com/spack/spack
+  #branch = develop
+  url = https://github.com/jcsda/spack
+  branch = jcsda_emc_spack_stack
 [submodule "doc/CMakeModules"]
   path = doc/CMakeModules
   url = https://github.com/noaa-emc/cmakemodules


### PR DESCRIPTION
This PR updates the spack hash commit in .gitmodules with the recently merged: https://github.com/JCSDA/spack/pull/277