### PR TITLE
Force spack-stack to utilize the built-in system iconv library on macos

### DIFF
--- a/configs/sites/macos.default/packages.yaml
+++ b/configs/sites/macos.default/packages.yaml
@@ -1,4 +1,9 @@
 packages:
+  libiconv:
+    buildable: false
+    externals:
+    - spec: libiconv@1.17
+      prefix: /usr
   wgrib2:
     variants: ~openmp
   cairo:


### PR DESCRIPTION
This PR fixes the build issue (eg. undefined symbol _iconv) with the climbfuji:feature/merge_spack_stack_20230710 branch on macos platforms.

Fixes: https://github.com/JCSDA/spack-stack/issues/698