### PR TITLE
Changes for NOAA Azure; remove intel/2018 compiler on NOAA pla…

### DIFF
--- a/configs/sites/noaa-aws/compilers.yaml
+++ b/configs/sites/noaa-aws/compilers.yaml
@@ -17,20 +17,6 @@ compilers:
         LD_LIBRARY_PATH: '/apps/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-9.2.0/lib64'
     extra_rpaths: []
 - compiler:
-    spec: intel@18.0.5
-    paths:
-      cc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/icc
-      cxx: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/icpc
-      f77: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
-      fc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - intel/18.0.5.274
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: gcc@9.2.0
     paths:
       cc: /apps/gnu/gcc-9.2.0/bin/gcc

--- a/configs/sites/noaa-aws/packages.yaml
+++ b/configs/sites/noaa-aws/packages.yaml
@@ -1,10 +1,8 @@
 packages:
   all:
     compiler:: [intel@2021.3.0, gcc@9.2.0]
-    #compiler:: [intel@18.0.5]
     providers:
       mpi:: [intel-oneapi-mpi@2021.3.0, openmpi@3.1.4]
-      #mpi:: [intel-mpi@2018.4.274]
 
 ### MPI, Python, MKL
   mpi:
@@ -15,12 +13,6 @@ packages:
       prefix: /apps/oneapi
       modules:
       - impi/2021.3.0
-  intel-mpi:
-    externals:
-    - spec: intel-mpi@2018.4.274%intel@18.0.5
-      prefix: /apps/intel/compilers_and_libraries_2018
-      modules:
-      - impi/2018.4.274
   openmpi:
     externals:
     - spec: openmpi@3.1.4%gcc@9.2.0

--- a/configs/sites/noaa-azure/compilers.yaml
+++ b/configs/sites/noaa-azure/compilers.yaml
@@ -17,20 +17,6 @@ compilers:
         LD_LIBRARY_PATH: '/apps/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-9.2.0/lib64'
     extra_rpaths: []
 - compiler:
-    spec: intel@18.0.5
-    paths:
-      cc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/icc
-      cxx: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/icpc
-      f77: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
-      fc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - intel/18.0.5.274
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: gcc@9.2.0
     paths:
       cc: /apps/gnu/gcc-9.2.0/bin/gcc

--- a/configs/sites/noaa-azure/packages.yaml
+++ b/configs/sites/noaa-azure/packages.yaml
@@ -1,10 +1,8 @@
 packages:
   all:
     compiler:: [intel@2021.3.0, gcc@9.2.0]
-    #compiler:: [intel@18.0.5]
     providers:
       mpi:: [intel-oneapi-mpi@2021.3.0, openmpi@3.1.4]
-      #mpi:: [intel-mpi@2018.4.274]
 
 ### MPI, Python, MKL
   mpi:
@@ -15,12 +13,6 @@ packages:
       prefix: /apps/oneapi
       modules:
       - impi/2021.3.0
-  intel-mpi:
-    externals:
-    - spec: intel-mpi@2018.4.274%intel@18.0.5
-      prefix: /apps/intel/compilers_and_libraries_2018
-      modules:
-      - impi/2018.4.274
   openmpi:
     externals:
     - spec: openmpi@3.1.4%gcc@9.2.0
@@ -50,10 +42,6 @@ packages:
     externals:
     - spec: berkeley-db@5.3.21
       prefix: /usr
-  cmake:
-    externals:
-    - spec: cmake@3.27.2
-      prefix: /contrib/spack-stack/cmake-3.27.2
   cpio:
     externals:
     - spec: cpio@2.11

--- a/configs/sites/noaa-gcloud/compilers.yaml
+++ b/configs/sites/noaa-gcloud/compilers.yaml
@@ -17,20 +17,6 @@ compilers:
         LD_LIBRARY_PATH: '/apps/oneapi/compiler/2021.3.0/linux/compiler/lib/intel64_lin:/apps/gnu/gcc-9.2.0/lib64'
     extra_rpaths: []
 - compiler:
-    spec: intel@18.0.5
-    paths:
-      cc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/icc
-      cxx: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/icpc
-      f77: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
-      fc: /apps/intel/parallel_studio_xe_2018.4.057/compilers_and_libraries_2018/linux/bin/intel64/ifort
-    flags: {}
-    operating_system: centos7
-    target: x86_64
-    modules:
-    - intel/18.0.5.274
-    environment: {}
-    extra_rpaths: []
-- compiler:
     spec: gcc@9.2.0
     paths:
       cc: /apps/gnu/gcc-9.2.0/bin/gcc

--- a/configs/sites/noaa-gcloud/packages.yaml
+++ b/configs/sites/noaa-gcloud/packages.yaml
@@ -1,10 +1,8 @@
 packages:
   all:
     compiler:: [intel@2021.3.0, gcc@9.2.0]
-    #compiler:: [intel@18.0.5]
     providers:
       mpi:: [intel-oneapi-mpi@2021.3.0, openmpi@3.1.4]
-      #mpi:: [intel-mpi@2018.4.274]
 
 ### MPI, Python, MKL
   mpi:
@@ -15,12 +13,6 @@ packages:
       prefix: /apps/oneapi
       modules:
       - impi/2021.3.0
-  intel-mpi:
-    externals:
-    - spec: intel-mpi@2018.4.274%intel@18.0.5
-      prefix: /apps/intel/compilers_and_libraries_2018
-      modules:
-      - impi/2018.4.274
   openmpi:
     externals:
     - spec: openmpi@3.1.4%gcc@9.2.0

--- a/configs/templates/unified-dev/spack.yaml
+++ b/configs/templates/unified-dev/spack.yaml
@@ -48,11 +48,3 @@ spack:
       exclude:
         # jedi-tools doesn't build with Intel
         - jedi-tools-env%intel
-        ## Don't even bother building those with Intel 18,
-        ## not needed. Many of the Python packages don't build.
-        #- ewok-env%intel@18
-        #- jedi-fv3-env%intel@18
-        #- jedi-tools-env%intel@18
-        #- jedi-ufs-env%intel@18
-        #- jedi-um-env%intel@18
-        #- soca-env%intel@18


### PR DESCRIPTION
1. Update for the NOAA Azure packages.yaml file, 
remove specification:
  cmake:
```
    externals:
    - spec: cmake@3.27.2
      prefix: /contrib/spack-stack/cmake-3.27.2
```

2. Remove intel/2018 compiler in NOAA Cloud platforms; leave intel/2021, gcc/9.2