### PR TITLE
Added config to use the external zlib for the orion Intel build.

### DIFF
--- a/configs/sites/tier1/orion/packages.yaml
+++ b/configs/sites/tier1/orion/packages.yaml
@@ -1,4 +1,17 @@
 packages:
+  # For addressing https://github.com/JCSDA/spack-stack/issues/1355
+  #   Use system zlib instead of spack-built zlib-ng
+  all:
+    providers:
+      zlib-api:: [zlib]
+  zlib-api:
+    buildable: False
+  zlib:
+    buildable: False
+    externals:
+    - spec: zlib@1.2.11
+      prefix: /usr
+
   autoconf:
     externals:
     - spec: autoconf@2.69

--- a/configs/sites/tier1/orion/packages_intel.yaml
+++ b/configs/sites/tier1/orion/packages_intel.yaml
@@ -1,4 +1,6 @@
 packages:
+  # For addressing https://github.com/JCSDA/spack-stack/issues/1355
+  #   Use system zlib instead of spack-built zlib-ng
   all:
     compiler:: [intel@2021.9.0,gcc@12.2.0]
     providers:
@@ -7,6 +9,16 @@ packages:
       blas:: [openblas]
       fftw-api:: [fftw]
       lapack:: [openblas]
+      zlib-api:: [zlib]
+
+  zlib-api:
+    buildable: False
+  zlib:
+    buildable: False
+    externals:
+    - spec: zlib@1.2.11
+      prefix: /usr
+
   mpi:
     buildable: False
   intel-oneapi-mpi:

--- a/configs/sites/tier1/orion/packages_intel.yaml
+++ b/configs/sites/tier1/orion/packages_intel.yaml
@@ -1,6 +1,4 @@
 packages:
-  # For addressing https://github.com/JCSDA/spack-stack/issues/1355
-  #   Use system zlib instead of spack-built zlib-ng
   all:
     compiler:: [intel@2021.9.0,gcc@12.2.0]
     providers:
@@ -9,16 +7,6 @@ packages:
       blas:: [openblas]
       fftw-api:: [fftw]
       lapack:: [openblas]
-      zlib-api:: [zlib]
-
-  zlib-api:
-    buildable: False
-  zlib:
-    buildable: False
-    externals:
-    - spec: zlib@1.2.11
-      prefix: /usr
-
   mpi:
     buildable: False
   intel-oneapi-mpi:


### PR DESCRIPTION
This PR adds configuration for building spack-stack on Orion using Intel compiler/mpi that forces spack-stack to use the external zlib instead of the spack built zlib-ng package. This is part of the solution for the issue with the Intel build on Orion breaking the system tar command.

The final part of the solution is to use the cmake builtin tar feature instead of the system tar command to unpack the CRTM test data (which is where the system tar command crashes).

Partially addresses jcsda/spack-stack/issues/1355